### PR TITLE
chore(nuget): reposition package metadata + README badges for discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bogoware Monads
 
-![Nuget](https://img.shields.io/nuget/dt/Bogoware.Monads?logo=nuget&style=plastic) ![Nuget](https://img.shields.io/nuget/v/Bogoware.Monads?style=plastic) [![Documentation](https://img.shields.io/badge/docs-online-blue)](https://bogoware.github.io/Monads/)
+[![Build](https://github.com/bogoware/Monads/actions/workflows/build.yml/badge.svg)](https://github.com/bogoware/Monads/actions/workflows/build.yml) ![Nuget](https://img.shields.io/nuget/v/Bogoware.Monads?style=plastic) ![Nuget](https://img.shields.io/nuget/dt/Bogoware.Monads?logo=nuget&style=plastic) [![License: MIT](https://img.shields.io/github/license/bogoware/Monads?style=plastic)](./LICENSE) [![Documentation](https://img.shields.io/badge/docs-online-blue)](https://bogoware.github.io/Monads/)
 
 _A functional programming library for C# providing `Result<T>` and `Maybe<T>` monads_
 

--- a/src/Monads/Monads.csproj
+++ b/src/Monads/Monads.csproj
@@ -19,9 +19,9 @@
         <Copyright>Copyright © Giovanni Costagliola 2023</Copyright>
         <NeutralLanguage>en-US</NeutralLanguage>
         <Title>Bogoware C# Monads</Title>
-        <Description>Provides Maybe and Result Monads suitable to support functional stye in C#.</Description>
-        <Summary>Provides Maybe and Result Monads suitable to support functional stye in C#.</Summary>
-        <PackageTags>c# functional maybe result success failure error some none map bind flatmap linq option either monad async</PackageTags>
+        <Description>Composable Result&lt;T&gt; and Maybe&lt;T&gt; monads for C#: type-safe, railway-oriented functional error handling. Multi-targets netstandard2.1, net8.0, net9.0, net10.0.</Description>
+        <Summary>Composable Result&lt;T&gt; and Maybe&lt;T&gt; monads for C#: type-safe, railway-oriented functional error handling.</Summary>
+        <PackageTags>c# csharp dotnet functional functional-programming monad maybe result option either error-handling railway-oriented-programming pattern-matching map bind flatmap linq async value-object discriminated-union</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>nuget-icon.png</PackageIcon>
         <PackageProjectUrl>https://bogoware.github.io/Monads/</PackageProjectUrl>


### PR DESCRIPTION
## Why

Groundwork for publicizing **Bogoware.Monads** on aggregator *awesome-lists*. The package is mature (NuGet **v11.5.0**, multi-targets netstandard2.1 + net8/9/10) but under-discovered. This polishes the metadata reviewers and search engines see, **before** we open the aggregator PRs.

## What

- **csproj** — rewrite `Description`/`Summary` to lead with `Result<T>`/`Maybe<T>`, *railway-oriented* functional error handling and multi-targeting (also fixes the `stye` → *style* typo). `<T>` is XML-escaped so it renders as `Result<T>` on nuget.org.
- **csproj** — expand `PackageTags` with discoverability keywords: `functional-programming`, `error-handling`, `railway-oriented-programming`, `option`, `value-object`, `discriminated-union` (dropped low-value noise like `success`/`failure`/`some`/`none`).
- **README** — add **CI build-status** badge (`build.yml`) and **MIT license** badge to the badge row.

> The live GitHub **description** and **topics** (18) were already updated via `gh repo edit` (they aren't file-tracked).

## Notes

- `<Version>0.0.1</Version>` in the csproj is intentionally **untouched** — it's a MinVer fallback; the real version comes from git tags (`v11.5.0`).
- Local `dotnet build` needs `-p:RestoreSources=https://api.nuget.org/v3/index.json` on this machine due to an unrelated stale local feed in the global `~/.nuget/NuGet/NuGet.Config` (not a repo issue).

## Test plan

- [x] `dotnet build -c Release src/Monads/Monads.csproj` succeeds (0 warnings, 0 errors), packs `Bogoware.Monads.11.5.0.nupkg`
- [x] Generated `.nuspec` shows the new `<description>` and `<tags>` with `<T>` correctly escaped
- [ ] README badge row renders on GitHub (verify after merge)
- [ ] CI `build.yml` badge resolves green